### PR TITLE
Extend api by using impl Into<String> instead of String

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,9 +63,9 @@ impl Qbit {
         }
     }
 
-    pub fn with_cookie(self, cookie: String) -> Self {
+    pub fn with_cookie(self, cookie: impl Into<String>) -> Self {
         Self {
-            cookie: Mutex::from(Some(cookie)),
+            cookie: Mutex::from(Some(cookie.into())),
             ..self
         }
     }

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -20,8 +20,8 @@ pub struct Credential {
 }
 
 impl Credential {
-    pub fn new(username: String, password: String) -> Self {
-        Self { username, password }
+    pub fn new(username: impl Into<String>, password: impl Into<String>) -> Self {
+        Self { username: username.into(), password: password.into() }
     }
 
     /// Return a dummy credential when you passed in the cookie instead of


### PR DESCRIPTION
Hey, 
I noticed that some constructors force the use of `String` which I changed to any `impl Into<String>` in order to allow the passing of `&str` and so on.