### PR TITLE
Fix incorrect request type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,7 +103,7 @@ impl Qbit {
     }
 
     pub async fn shutdown(&self) -> Result<()> {
-        self.get("app/shutdown").await?.end()
+        self.post("app/shutdown", NONE).await?.end()
     }
 
     pub async fn get_preferences(&self) -> Result<Preferences> {


### PR DESCRIPTION
The shutdown endpoint is a POST with an empty body and not a GET. Currently you get a 405 error when calling it.