### PR TITLE
fix proxy_type

### DIFF
--- a/src/model/app.rs
+++ b/src/model/app.rs
@@ -173,7 +173,7 @@ pub struct Preferences {
     /// built against libtorrent version 0.16.X and higher
     pub anonymous_mode: Option<bool>,
     /// See list of possible values here below
-    pub proxy_type: Option<i64>,
+    pub proxy_type: Option<String>,
     /// Proxy IP address or domain name
     pub proxy_ip: Option<String>,
     /// Proxy port


### PR DESCRIPTION
With v4.6.1, I have:
`
proxy_type: "None"`
