### PR TITLE
Updating readme, fixing a missing enum variant

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,8 @@ builder = ["dep:typed-builder"]
 [dependencies]
 typed-builder = { version = "0.14.0", optional = true }
 serde         = { version = "1.0.159", features = ["derive"] }
-
+reqwest       = { version = "0.11.16", features = ["json"] }
+url           = { version = "2.3.1", features = ["serde"] }
 
 mod_use     = "0.2.1"
 serde-value = "0.7.0"
@@ -36,9 +37,7 @@ serde_with  = "2.3.2"
 tap         = "1.0.1"
 thiserror   = "1.0.40"
 tracing     = "0.1.37"
-reqwest     = { version = "0.11.16", features = ["json"] }
-url = { version = "2.3.1", features = ["serde"] }
-serde_json = "1.0.96"
+serde_json  = "1.0.96"
 
 [dev-dependencies]
 tokio = { version = "1.27.0", features = ["full"] }

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ qbit-rs = "0.3"
 And this to your crate:
 
 ```rust,ignore
-use qbit_rs::{Qbit, Credential};
+use qbit_rs::Qbit;
+use qbit_rs::model::Credential;
 
 let credential = Credential::new("admin", "adminadmin");
 let api = Qbit::new(url, credential); // Or alternatively use `Qbit::new_with_client`

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -86,16 +86,16 @@ pub struct Tracker {
 #[repr(i8)]
 pub enum TrackerStatus {
     /// Tracker is disabled (used for DHT, PeX, and LSD)
-    Disabled = 0,
+    Disabled     = 0,
     /// Tracker has not been contacted yet
     NotContacted = 1,
     /// Tracker has been contacted and is working
-    Working = 2,
+    Working      = 2,
     /// Tracker is updating
-    Updating = 3,
+    Updating     = 3,
     /// Tracker has been contacted, but it is not working (or doesn't send
     /// proper replies)
-    NotWorking = 4,
+    NotWorking   = 4,
 }
 
 /// A wrapper around `Vec<T>` that implements `FromStr` and `ToString` as

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -21,7 +21,10 @@ pub struct Credential {
 
 impl Credential {
     pub fn new(username: impl Into<String>, password: impl Into<String>) -> Self {
-        Self { username: username.into(), password: password.into() }
+        Self {
+            username: username.into(),
+            password: password.into(),
+        }
     }
 
     /// Return a dummy credential when you passed in the cookie instead of
@@ -83,16 +86,16 @@ pub struct Tracker {
 #[repr(i8)]
 pub enum TrackerStatus {
     /// Tracker is disabled (used for DHT, PeX, and LSD)
-    Disabled     = 0,
+    Disabled = 0,
     /// Tracker has not been contacted yet
     NotContacted = 1,
     /// Tracker has been contacted and is working
-    Working      = 2,
+    Working = 2,
     /// Tracker is updating
-    Updating     = 3,
+    Updating = 3,
     /// Tracker has been contacted, but it is not working (or doesn't send
     /// proper replies)
-    NotWorking   = 4,
+    NotWorking = 4,
 }
 
 /// A wrapper around `Vec<T>` that implements `FromStr` and `ToString` as

--- a/src/model/torrent.rs
+++ b/src/model/torrent.rs
@@ -300,6 +300,8 @@ pub enum Priority {
     DoNotDownload = 0,
     /// Normal priority
     Normal        = 1,
+    /// Mixed
+    Mixed = 4,
     /// High priority
     High          = 6,
     /// Maximal priority

--- a/src/model/torrent.rs
+++ b/src/model/torrent.rs
@@ -301,7 +301,7 @@ pub enum Priority {
     /// Normal priority
     Normal        = 1,
     /// Mixed
-    Mixed = 4,
+    Mixed         = 4,
     /// High priority
     High          = 6,
     /// Maximal priority


### PR DESCRIPTION
* There's a `4` response coming back when all files don't have the same priority, which was causing deserialisation to fail.
* The README example didn't work for me, had to import `Credential` from `qbit_rs::model`.