### PR TITLE
fix: missing fields on sync struct

### DIFF
--- a/src/model/sync.rs
+++ b/src/model/sync.rs
@@ -9,7 +9,7 @@ pub struct SyncData {
     /// Response ID
     pub rid: i64,
     /// Whether the response contains all the data or partial data
-    pub full_update: bool,
+    pub full_update: Option<bool>,
     /// Property: torrent hash, value: same as [torrent list](#get-torrent-list)
     pub torrents: Option<HashMap<String, Torrent>>,
     /// List of hashes of torrents removed since last request

--- a/src/model/sync.rs
+++ b/src/model/sync.rs
@@ -22,6 +22,11 @@ pub struct SyncData {
     pub tags: Option<Vec<String>>,
     /// List of tags removed since last request
     pub tags_removed: Option<Vec<String>>,
+    /// Map of trackers added since last request, and the torrents that have
+    /// them. Property: tracker URL, value: torrent hash
+    pub trackers: Option<HashMap<String, Vec<String>>>,
+    /// List of tracker URLs removed since last request
+    pub trackers_removed: Option<Vec<String>>,
     /// Global transfer info
     pub server_state: Option<HashMap<String, Value>>,
 }


### PR DESCRIPTION
There are two (as of yet) undocumented fields on [the sync endpoint](https://docs.rs/qbit-rs/latest/qbit_rs/struct.Qbit.html#method.sync) that qbit does not currently support. These fields are `trackers` and `trackers_removed`, and they are similar to the `categories` and `categories_removed` fields.

I've opened a bug report against qBittorrent addressing this documentation error.

This commit adds the two fields to the [`SyncData`](https://docs.rs/qbit-rs/latest/qbit_rs/model/struct.SyncData.html) struct.

Feel free to rewrite the doc comments, or to change the types. I wasn't quite sure what would fit best.

Thank you for your work on this project!