### PR TITLE
fix: Peer and PeerSyncData structs

### DIFF
--- a/src/model/sync.rs
+++ b/src/model/sync.rs
@@ -35,7 +35,7 @@ pub struct SyncData {
 pub struct PeerSyncData {
     pub full_update: Option<bool>,
     pub peers: HashMap<SocketAddr, Peer>,
-    pub peers_removed: Vec<SocketAddr>,
+    pub peers_removed: Option<Vec<SocketAddr>>,
     pub rid: i64,
     pub show_flags: bool,
 }

--- a/src/model/sync.rs
+++ b/src/model/sync.rs
@@ -52,7 +52,7 @@ pub struct Peer {
     pub flags_desc: Option<String>,
     pub ip: Option<String>,
     pub port: Option<u16>,
-    pub progress: Option<u64>,
+    pub progress: Option<f64>,
     pub relevance: Option<u64>,
     pub up_speed: Option<u64>,
     pub uploaded: Option<u64>,

--- a/src/model/sync.rs
+++ b/src/model/sync.rs
@@ -33,8 +33,9 @@ pub struct SyncData {
 
 #[derive(Debug, Clone, serde::Deserialize, PartialEq)]
 pub struct PeerSyncData {
-    pub full_update: bool,
+    pub full_update: Option<bool>,
     pub peers: HashMap<SocketAddr, Peer>,
+    pub peers_removed: Vec<SocketAddr>,
     pub rid: i64,
     pub show_flags: bool,
 }


### PR DESCRIPTION
Similarly to the changes made in #8, these commits make the `full_update` field in [`PeerSyncData`](https://docs.rs/qbit-rs/latest/qbit_rs/model/struct.PeerSyncData.html) optional. In addition, I've added the missing `peers_removed` field, which behaves similarly to the other `*_removed` fields in [`SyncData`](https://docs.rs/qbit-rs/latest/qbit_rs/model/struct.SyncData.html) (in this case, it's a list of socket addresses to remove).

Also, the [`Peer`](https://docs.rs/qbit-rs/latest/qbit_rs/model/struct.PeerSyncData.html) struct incorrectly defined `progress` as an `Option<u64>`, when it should be an `Option<f64>` (between 0.0 and 1.0, representing 0% and 100% completion).

