### PR TITLE
fix: PeerSyncData peers field is optional

### DIFF
--- a/src/model/sync.rs
+++ b/src/model/sync.rs
@@ -34,7 +34,7 @@ pub struct SyncData {
 #[derive(Debug, Clone, serde::Deserialize, PartialEq)]
 pub struct PeerSyncData {
     pub full_update: Option<bool>,
-    pub peers: HashMap<SocketAddr, Peer>,
+    pub peers: Option<HashMap<SocketAddr, Peer>>,
     pub peers_removed: Option<Vec<SocketAddr>>,
     pub rid: i64,
     pub show_flags: bool,


### PR DESCRIPTION
Sorry to open a third pull request, I somehow only just noticed this mistake *after* you'd merged my previous one :sweat_smile: 

This is a very small change, just making the `peers` field on `PeerSyncData` optional.

If I notice any further mistakes after this, I'll wait a few days before opening a PR.