### PR TITLE
feat: add some RSS API methods

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "qbit-rs"
-version       = "0.4.1"
+version       = "0.4.2"
 edition       = "2021"
 license       = "MIT"
 description   = "A Rust library for interacting with qBittorrent's Web API"
@@ -26,19 +26,19 @@ docs       = []
 builder = ["dep:typed-builder"]
 
 [dependencies]
-typed-builder = { version = "0.14.0", optional = true }
-serde         = { version = "1.0.159", features = ["derive"] }
+typed-builder = { version = "0.18.2", optional = true }
+serde         = { version = "1.0.202", features = ["derive"] }
 reqwest       = { version = "0.12.4", default-features = false, features = ["charset", "http2", "macos-system-configuration", "json"] }
-url           = { version = "2.3.1", features = ["serde"] }
+url           = { version = "2.5.0", features = ["serde"] }
 
 mod_use     = "0.2.1"
 serde-value = "0.7.0"
-serde_repr  = "0.1.12"
-serde_with  = "2.3.2"
+serde_repr  = "0.1.19"
+serde_with  = "2.3.3"
 tap         = "1.0.1"
-thiserror   = "1.0.40"
-tracing     = "0.1.37"
-serde_json  = "1.0.96"
+thiserror   = "1.0.61"
+tracing     = "0.1.40"
+serde_json  = "1.0.117"
 
 [dev-dependencies]
 tokio = { version = "1.27.0", features = ["full"] }

--- a/README.md
+++ b/README.md
@@ -126,16 +126,16 @@ Most of the API is covered, except `RSS` and `Search`. PR is welcomed if you nee
    1. [x] [Rename file](https://docs.rs/qbit-rs/latest/qbit_rs/struct.Qbit.html#method.rename_file)
    1. [x] [Rename folder](https://docs.rs/qbit-rs/latest/qbit_rs/struct.Qbit.html#method.rename_folder)
 1. [ ] RSS (experimental)
-   1. [x] Add folder
-   1. [x] Add feed
-   1. [x] Remove item
-   1. [x] Move item
+   1. [x] [Add folder](https://docs.rs/qbit-rs/latest/qbit_rs/struct.Qbit.html#method.add_folder)
+   1. [x] [Add feed](https://docs.rs/qbit-rs/latest/qbit_rs/struct.Qbit.html#method.add_feed)
+   1. [x] [Remove item](https://docs.rs/qbit-rs/latest/qbit_rs/struct.Qbit.html#method.remove_item)
+   1. [x] [Move item](https://docs.rs/qbit-rs/latest/qbit_rs/struct.Qbit.html#method.move_item)
    1. [ ] Get all items
-   1. [x] Mark as read
-   1. [x] Refresh item
+   1. [x] [Mark as read](https://docs.rs/qbit-rs/latest/qbit_rs/struct.Qbit.html#method.mark_as_read)
+   1. [x] [Refresh item](https://docs.rs/qbit-rs/latest/qbit_rs/struct.Qbit.html#method.refresh_item)
    1. [ ] Set auto-downloading rule
-   1. [x] Rename auto-downloading rule
-   1. [x] Remove auto-downloading rule
+   1. [x] [Rename auto-downloading rule](https://docs.rs/qbit-rs/latest/qbit_rs/struct.Qbit.html#method.rename_rule)
+   1. [x] [Remove auto-downloading rule](https://docs.rs/qbit-rs/latest/qbit_rs/struct.Qbit.html#method.remove_rule)
    1. [ ] Get all auto-downloading rules
    1. [ ] Get all articles matching a rule
 1. [ ] Search

--- a/README.md
+++ b/README.md
@@ -126,16 +126,16 @@ Most of the API is covered, except `RSS` and `Search`. PR is welcomed if you nee
    1. [x] [Rename file](https://docs.rs/qbit-rs/latest/qbit_rs/struct.Qbit.html#method.rename_file)
    1. [x] [Rename folder](https://docs.rs/qbit-rs/latest/qbit_rs/struct.Qbit.html#method.rename_folder)
 1. [ ] RSS (experimental)
-   1. [ ] Add folder
-   1. [ ] Add feed
-   1. [ ] Remove item
-   1. [ ] Move item
+   1. [x] Add folder
+   1. [x] Add feed
+   1. [x] Remove item
+   1. [x] Move item
    1. [ ] Get all items
-   1. [ ] Mark as read
-   1. [ ] Refresh item
+   1. [x] Mark as read
+   1. [x] Refresh item
    1. [ ] Set auto-downloading rule
-   1. [ ] Rename auto-downloading rule
-   1. [ ] Remove auto-downloading rule
+   1. [x] Rename auto-downloading rule
+   1. [x] Remove auto-downloading rule
    1. [ ] Get all auto-downloading rules
    1. [ ] Get all articles matching a rule
 1. [ ] Search

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1167,6 +1167,163 @@ impl Qbit {
         .end()
     }
 
+    pub async fn add_folder<T: AsRef<str> + Send + Sync>(&self, path: T) -> Result<()> {
+        #[derive(Serialize)]
+        struct Arg<'a> {
+            path: &'a str,
+        }
+
+        self.post(
+            "rss/addFolder",
+            Some(&Arg {
+                path: path.as_ref(),
+            }),
+        )
+        .await?
+        .end()
+    }
+
+    pub async fn add_feed<T: AsRef<str> + Send + Sync>(
+        &self,
+        url: T,
+        path: Option<T>,
+    ) -> Result<()> {
+        #[derive(Serialize)]
+        struct Arg<'a> {
+            url: &'a str,
+            path: Option<&'a str>,
+        }
+
+        self.post(
+            "rss/addFeed",
+            Some(&Arg {
+                url: url.as_ref(),
+                path: path.as_ref().map(AsRef::as_ref),
+            }),
+        )
+        .await?
+        .end()
+    }
+
+    pub async fn remove_item<T: AsRef<str> + Send + Sync>(&self, path: T) -> Result<()> {
+        #[derive(Serialize)]
+        struct Arg<'a> {
+            path: &'a str,
+        }
+
+        self.post(
+            "rss/removeItem",
+            Some(&Arg {
+                path: path.as_ref(),
+            }),
+        )
+        .await?
+        .end()
+    }
+
+    pub async fn move_item<T: AsRef<str> + Send + Sync>(
+        &self,
+        item_path: T,
+        dest_path: T,
+    ) -> Result<()> {
+        #[derive(Serialize)]
+        #[serde(rename_all = "camelCase")]
+        struct Arg<'a> {
+            item_path: &'a str,
+            dest_path: &'a str,
+        }
+
+        self.post(
+            "rss/moveItem",
+            Some(&Arg {
+                item_path: item_path.as_ref(),
+                dest_path: dest_path.as_ref(),
+            }),
+        )
+        .await?
+        .end()
+    }
+
+    pub async fn mark_as_read<T: AsRef<str> + Send + Sync>(
+        &self,
+        item_path: T,
+        article_id: Option<T>,
+    ) -> Result<()> {
+        #[derive(Serialize)]
+        #[serde(rename_all = "camelCase")]
+        struct Arg<'a> {
+            item_path: &'a str,
+            article_id: Option<&'a str>,
+        }
+
+        self.post(
+            "rss/markAsRead",
+            Some(&Arg {
+                item_path: item_path.as_ref(),
+                article_id: article_id.as_ref().map(AsRef::as_ref),
+            }),
+        )
+        .await?
+        .end()
+    }
+
+    pub async fn refresh_item<T: AsRef<str> + Send + Sync>(&self, item_path: T) -> Result<()> {
+        #[derive(Serialize)]
+        #[serde(rename_all = "camelCase")]
+        struct Arg<'a> {
+            item_path: &'a str,
+        }
+
+        self.post(
+            "rss/refreshItem",
+            Some(&Arg {
+                item_path: item_path.as_ref(),
+            }),
+        )
+        .await?
+        .end()
+    }
+
+    pub async fn rename_rule<T: AsRef<str> + Send + Sync>(
+        &self,
+        rule_name: T,
+        new_rule_name: T,
+    ) -> Result<()> {
+        #[derive(Serialize)]
+        #[serde(rename_all = "camelCase")]
+        struct Arg<'a> {
+            rule_name: &'a str,
+            new_rule_name: &'a str,
+        }
+
+        self.post(
+            "rss/renameRule",
+            Some(&Arg {
+                rule_name: rule_name.as_ref(),
+                new_rule_name: new_rule_name.as_ref(),
+            }),
+        )
+        .await?
+        .end()
+    }
+
+    pub async fn remove_rule<T: AsRef<str> + Send + Sync>(&self, rule_name: T) -> Result<()> {
+        #[derive(Serialize)]
+        #[serde(rename_all = "camelCase")]
+        struct Arg<'a> {
+            rule_name: &'a str,
+        }
+
+        self.post(
+            "rss/removeRule",
+            Some(&Arg {
+                rule_name: rule_name.as_ref(),
+            }),
+        )
+        .await?
+        .end()
+    }
+
     fn url(&self, path: &'static str) -> Url {
         self.endpoint
             .join("api/v2/")


### PR DESCRIPTION
Added the following RSS API methods:

- [x]  Add folder
- [x]  Add feed
- [x]  Remove item
- [x]  Move item
- [ ]  Get all items
- [x]  Mark as read
- [x]  Refresh item
- [ ]  Set auto-downloading rule
- [x]  Rename auto-downloading rule
- [x]  Remove auto-downloading rule
- [ ]  Get all auto-downloading rules
- [ ]  Get all articles matching a rule

This pull request does not include any new struct, only relatively simple operations. 
All functions should have been tested, but if there are any issues please let me know.

Thanks a lot for your work!