### PR TITLE
Fix add_torrent api

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ builder = ["dep:typed-builder"]
 [dependencies]
 typed-builder = { version = "0.18.2", optional = true }
 serde         = { version = "1.0.202", features = ["derive"] }
-reqwest       = { version = "0.12.4", default-features = false, features = ["charset", "http2", "macos-system-configuration", "json"] }
+reqwest       = { version = "0.12.4", default-features = false, features = ["charset", "http2", "macos-system-configuration", "json", "multipart"] }
 url           = { version = "2.5.0", features = ["serde"] }
 
 mod_use     = "0.2.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1647,10 +1647,27 @@ mod test {
         let arg = AddTorrentArg {
             source: TorrentSource::Urls {
                 urls: vec![
-                    "https://releases.ubuntu.com/20.04/ubuntu-20.04.1-desktop-amd64.iso.torrent"
+                    "https://releases.ubuntu.com/22.04/ubuntu-22.04.4-desktop-amd64.iso.torrent"
                         .parse()
                         .unwrap(),
                 ]
+                .into(),
+            },
+            ..AddTorrentArg::default()
+        };
+        client.add_torrent(arg).await.unwrap();
+    }
+    #[tokio::test]
+    async fn test_add_torrent_file() {
+        let client = prepare().await.unwrap();
+        let arg = AddTorrentArg {
+            source: TorrentSource::TorrentFiles {
+                torrents: vec![(
+                    "ubuntu-22.04.4-desktop-amd64.iso.torrent".to_string(),
+                    reqwest::get(
+                        "https://releases.ubuntu.com/22.04/ubuntu-22.04.4-desktop-amd64.iso.torrent",
+                    ).await.unwrap().bytes().await.unwrap().to_vec(),
+                )]
                 .into(),
             },
             ..AddTorrentArg::default()

--- a/src/model/torrent.rs
+++ b/src/model/torrent.rs
@@ -390,10 +390,15 @@ pub struct GetTorrentListArg {
 pub enum TorrentSource {
     /// URLs
     Urls { urls: Sep<Url, '\n'> },
-    /// Raw data of torrent file.
-    TorrentFiles { torrents: Vec<(String, Vec<u8>)> },
+    /// Torrent files
+    TorrentFiles { torrents: Vec<TorrentFile> },
 }
-
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+/// Torrent file
+pub struct TorrentFile {
+    pub filename: String,
+    pub data: Vec<u8>
+}
 impl Default for TorrentSource {
     fn default() -> Self {
         TorrentSource::Urls {

--- a/src/model/torrent.rs
+++ b/src/model/torrent.rs
@@ -391,7 +391,7 @@ pub enum TorrentSource {
     /// URLs
     Urls { urls: Sep<Url, '\n'> },
     /// Raw data of torrent file.
-    TorrentFiles { torrents: Vec<u8> },
+    TorrentFiles { torrents: Vec<(String, Vec<u8>)> },
 }
 
 impl Default for TorrentSource {
@@ -401,7 +401,9 @@ impl Default for TorrentSource {
         }
     }
 }
-
+fn is_torrent_files(source: &TorrentSource) -> bool {
+    matches!(source, TorrentSource::TorrentFiles { .. })
+}
 #[cfg_attr(feature = "builder", derive(typed_builder::TypedBuilder))]
 #[cfg_attr(
     feature = "builder",
@@ -412,47 +414,75 @@ impl Default for TorrentSource {
 pub struct AddTorrentArg {
     #[serde(flatten)]
     #[cfg_attr(feature = "builder", builder(!default, setter(!strip_option)))]
+    #[serde(skip_serializing_if = "is_torrent_files")]
     pub source: TorrentSource,
+    #[serde(skip_serializing_if = "Option::is_none")]
     /// Download folder
     pub savepath: Option<String>,
     /// Cookie sent to download the .torrent file
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub cookie: Option<String>,
     /// Category for the torrent
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub category: Option<String>,
+
     /// Tags for the torrent, split by ','
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub tags: Option<String>,
+
     /// Skip hash checking. Possible values are `true`, `false` (default)
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub skip_checking: Option<String>,
+
     /// Add torrents in the paused state. Possible values are `true`, `false`
     /// (default)
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub paused: Option<String>,
+
     /// Create the root folder. Possible values are `true`, `false`, unset
     /// (default)
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub root_folder: Option<String>,
+
     /// Rename torrent
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub rename: Option<String>,
+
     /// Set torrent upload speed limit. Unit in bytes/second
     #[serde(rename = "upLimit")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub up_limit: Option<i64>,
+
     /// Set torrent download speed limit. Unit in bytes/second
     #[serde(rename = "dlLimit")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub download_limit: Option<i64>,
+
     /// Set torrent share ratio limit
     #[serde(rename = "ratioLimit")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub ratio_limit: Option<f64>,
+
     /// Set torrent seeding time limit. Unit in minutes
     #[serde(rename = "seedingTimeLimit")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub seeding_time_limit: Option<i64>,
+
     /// Whether Automatic Torrent Management should be used
     #[serde(rename = "autoTMM")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub auto_torrent_management: Option<bool>,
+
     /// Enable sequential download. Possible values are `true`, `false`
     /// (default)
     #[serde(rename = "sequentialDownload")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub sequential_download: Option<String>,
+
     /// Prioritize download first last piece. Possible values are `true`,
     /// `false` (default)
     #[serde(rename = "firstLastPiecePrio")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub first_last_piece_priority: Option<String>,
 }
 


### PR DESCRIPTION
change the add_torrent method and AddTorrentArg and it's source to support torrent from file.

The add_torrent method no longer uses the generic post and request methods, but given that there is only one place in the qbittorrent api that sends raw data, such a hack is acceptable.
Probably clone torrent file bytes unnecessarily. unoptimized considering the size of the torrent file.

Added the test and incidentally fixed the failure of the torrent link in the test.