### PR TITLE
Added new torrent states introduced in qBit5.0

### DIFF
--- a/src/model/torrent.rs
+++ b/src/model/torrent.rs
@@ -134,8 +134,9 @@ pub enum State {
     /// Torrent is being seeded and data is being transferred
     #[serde(rename = "uploading")]
     Uploading,
-    /// Torrent is paused and has finished downloading
-    #[serde(rename = "pausedUP")]
+    /// Torrent is paused and has finished downloading, 
+    /// stoppedUP is new name in qBit5+
+    #[serde(rename = "pausedUP", alias = "stoppedUP")]
     PausedUP,
     /// Queuing is enabled and torrent is queued for upload
     #[serde(rename = "queuedUP")]
@@ -158,8 +159,9 @@ pub enum State {
     /// Torrent has just started downloading and is fetching metadata
     #[serde(rename = "metaDL")]
     MetaDL,
-    /// Torrent is paused and has NOT finished downloading
-    #[serde(rename = "pausedDL")]
+    /// Torrent is paused and has NOT finished downloading,
+    /// stoppedDL is new name in qBit5+
+    #[serde(rename = "pausedDL", alias = "stoppedDL")]
     PausedDL,
     /// Queuing is enabled and torrent is queued for download
     #[serde(rename = "queuedDL")]


### PR DESCRIPTION
Release of qBittorrent 5.0 renamed pausedUP and pausedDL to stoppedUP and stoppedDL. This just adds the states to the model, but not sure if this is the best way to handle this. If it were better to just remove them or leave them as is. Fortunately, from the limited part of this crate I use, this is the only breakage I experienced when updating.

Unfortunately https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1) is still not updated to latest version so not sure how many other changes there were.