### PR TITLE
Add missing inactive seeding time parameter

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -283,7 +283,7 @@ impl Qbit {
     }
 
     pub async fn toggle_speed_limits_mode(&self) -> Result<()> {
-        self.get("transfer/toggleSpeedLimitsMode").await?.end()
+        self.post("transfer/toggleSpeedLimitsMode", None::<&()>).await?.end()
     }
 
     pub async fn get_download_limit(&self) -> Result<u64> {

--- a/src/model/torrent.rs
+++ b/src/model/torrent.rs
@@ -503,6 +503,8 @@ pub struct SetTorrentSharedLimitArg {
     pub ratio_limit: Option<RatioLimit>,
     #[cfg_attr(feature = "builder", builder(default, setter(strip_option)))]
     pub seeding_time_limit: Option<SeedingTimeLimit>,
+    #[cfg_attr(feature = "builder", builder(default, setter(strip_option)))]
+    pub inactive_seeding_time_limit: Option<SeedingTimeLimit>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]


### PR DESCRIPTION
I noticed a missing field in `SetTorrentSharedLimitArg`.
The upstream docs specify an additional inactive seeding time limit for the `/torrents/setShareLimits` api call. [reference](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)#set-torrent-share-limit)

