### PR TITLE
Fix issue #24 : extra quotes appeared in category when adding a torrent

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -17,3 +17,4 @@ use_field_init_shorthand = true
 format_strings = true
 format_code_in_doc_comments = true
 format_macro_matchers = true
+edition = "2021"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,7 +77,6 @@ pub struct Qbit {
     state: Mutex<LoginState>,
 }
 
-
 impl Qbit {
     /// Create a new [`QbitBuilder`] to build a [`Qbit`] instance.
     pub fn builder() -> QbitBuilder {
@@ -516,12 +515,14 @@ impl Qbit {
                             .unwrap()
                             .into_iter()
                             .fold(reqwest::multipart::Form::new(), |form, (k, v)| {
-                                form.text(k.to_string(),
+                                form.text(
+                                    k.to_string(),
                                     if let serde_json::Value::String(s) = v {
-                                        s
+                                        s.to_owned()
                                     } else {
                                         v.to_string()
-                                    })
+                                    },
+                                )
                             }),
                         |mut form, torrent| {
                             let p = reqwest::multipart::Part::bytes(torrent.data.clone())
@@ -1515,7 +1516,11 @@ impl Qbit {
 impl Clone for Qbit {
     fn clone(&self) -> Self {
         let state = self.state.lock().unwrap().clone();
-        Self { client: self.client.clone(), endpoint: self.endpoint.clone(), state: Mutex::new(state)  }
+        Self {
+            client: self.client.clone(),
+            endpoint: self.endpoint.clone(),
+            state: Mutex::new(state),
+        }
     }
 }
 
@@ -1699,5 +1704,4 @@ mod test {
             .unwrap();
         print!("{:#?}", list);
     }
-
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -516,7 +516,12 @@ impl Qbit {
                             .unwrap()
                             .into_iter()
                             .fold(reqwest::multipart::Form::new(), |form, (k, v)| {
-                                form.text(k.to_string(), v.to_string())
+                                form.text(k.to_string(),
+                                    if let serde_json::Value::String(s) = v {
+                                        s
+                                    } else {
+                                        v.to_string()
+                                    })
                             }),
                         |mut form, torrent| {
                             let p = reqwest::multipart::Part::bytes(torrent.data.clone())


### PR DESCRIPTION
I had the problem with savepath parameter. Quite the same fix as #23, though.