### PR TITLE
TorrentContent->piece_range can contain a negative int

### DIFF
--- a/src/model/torrent.rs
+++ b/src/model/torrent.rs
@@ -279,7 +279,7 @@ pub struct TorrentContent {
     /// The first number is the starting piece index and the second number is
     /// the ending piece index (inclusive),
     #[serde(default)]
-    pub piece_range: Vec<u64>,
+    pub piece_range: Vec<i64>,
     /// Percentage of file pieces currently available (percentage/100),
     #[serde(default)]
     pub availability: f64,


### PR DESCRIPTION
`piece_range` can be `[0, -1]` when file is 0 B in size.