### PR TITLE
Fix parsing of TorrentContent piece_range, it can be negative

### DIFF
--- a/src/model/torrent.rs
+++ b/src/model/torrent.rs
@@ -279,7 +279,7 @@ pub struct TorrentContent {
     /// The first number is the starting piece index and the second number is
     /// the ending piece index (inclusive),
     #[serde(default)]
-    pub piece_range: Vec<u64>,
+    pub piece_range: Vec<i64>,
     /// Percentage of file pieces currently available (percentage/100),
     #[serde(default)]
     pub availability: f64,


### PR DESCRIPTION
Hello!

I found an issue when retrieving the TorrentContent, looking at the HTTP response piece_range can be negative, in my case this was obtained from the qBittorrent API. 
```
"piece_range": [0, -1],
```

qBittorrent version: v5.0.4