### PR TITLE
fix: change `Peer`'s relevance type from `Option<u64>` to `Option<f64>`

### DIFF
--- a/src/model/sync.rs
+++ b/src/model/sync.rs
@@ -53,7 +53,7 @@ pub struct Peer {
     pub ip: Option<String>,
     pub port: Option<u16>,
     pub progress: Option<f64>,
-    pub relevance: Option<u64>,
+    pub relevance: Option<f64>,
     pub up_speed: Option<u64>,
     pub uploaded: Option<u64>,
 }


### PR DESCRIPTION
Qbit.get_torrent_peers() fails to unwrap()

```
called `Result::unwrap()` on an `Err` value: HttpError(reqwest::Error { kind: Decode, source: Error("invalid type: floating point `0.5333333333333333`, expected u64", line: 1, column: 474) })
```

peer info's relevance type should be f64 (qreal)


see: https://github.com/qbittorrent/qBittorrent/blob/master/src/base/bittorrent/peerinfo.h#L89