### PR TITLE
Expose `file_log_path` in preference

### DIFF
--- a/src/model/app.rs
+++ b/src/model/app.rs
@@ -65,6 +65,8 @@ pub struct Preferences {
     /// Path to directory to copy .torrent files of completed downloads to.
     /// Slashes are used as path separators
     pub export_dir_fin: Option<String>,
+    /// Log file directory path
+    pub file_log_path: Option<String>,
     /// True if e-mail notification should be enabled
     pub mail_notification_enabled: Option<bool>,
     /// e-mail where notifications should originate from


### PR DESCRIPTION
Exposed the file log directory path (`file_log_path`) in the preference object so I can read it through the library without resorting to raw HTTP requests outside the library.