### PR TITLE
Api key auth

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,22 +31,13 @@ jobs:
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
 
-      - name: Install qBittorrent
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y qbittorrent-nox
-
-      - name: Start qBittorrent
+      - name: Start qBittorrent (Docker)
         run: |
           set -euo pipefail
-          config_dir="$HOME/.config/qBittorrent"
-          mkdir -p "$config_dir"
 
-          # qBittorrent stores the WebUI password as a PBKDF2-HMAC-SHA512 hash.
-          # Seed a known one so the tests can log in with QBIT_PASSWORD instead
-          # of the random temporary password qBittorrent generates otherwise.
           pbkdf2=$(python3 -c "import base64, hashlib, os; salt = os.urandom(16); digest = hashlib.pbkdf2_hmac('sha512', b'$QBIT_PASSWORD', salt, 100000); print('@ByteArray(' + base64.b64encode(salt).decode() + ':' + base64.b64encode(digest).decode() + ')')")
 
+          mkdir -p /tmp/qbit-config
           {
             printf '%s\n' '[LegalNotice]'
             printf '%s\n' 'Accepted=true'
@@ -58,30 +49,59 @@ jobs:
             printf '%s\n' 'WebUI\LocalHostAuth=true'
             printf '%s\n' 'WebUI\CSRFProtection=false'
             printf '%s\n' 'WebUI\HostHeaderValidation=false'
-          } > "$config_dir/qBittorrent.conf"
+          } > /tmp/qbit-config/qBittorrent.conf
 
-          qbittorrent-nox --webui-port=8080 > "$RUNNER_TEMP/qbit.log" 2>&1 &
+          docker run -d --name qbit --network host \
+            -v /tmp/qbit-config:/root/.config/qBittorrent \
+            ubuntu:plucky bash -c '
+              apt-get update
+              apt-get install -y software-properties-common
+              add-apt-repository -y ppa:qbittorrent-team/qbittorrent-unstable
+              apt-get update
+              DEBIAN_FRONTEND=noninteractive apt-get install -y qbittorrent-nox
+              exec qbittorrent-nox --webui-port=8080
+            '
 
           echo "Waiting for the WebUI to come up..."
-          for _ in $(seq 1 30); do
+          for _ in $(seq 1 60); do
             code=$(curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:8080 || true)
             if [ "$code" != "000" ]; then
               echo "qBittorrent is up (HTTP $code)"
-              exit 0
+              break
             fi
             sleep 1
           done
 
-          echo "qBittorrent did not start in time:"
-          cat "$RUNNER_TEMP/qbit.log"
-          exit 1
+          if [ "$code" = "000" ]; then
+            echo "qBittorrent did not start in time"
+            docker logs qbit
+            exit 1
+          fi
+
+          # Login and rotate the API key to get a known one.
+          cookie_jar=$(mktemp)
+          curl -fsS -c "$cookie_jar" -X POST http://127.0.0.1:8080/api/v2/auth/login \
+            -d "username=$QBIT_USERNAME&password=$QBIT_PASSWORD"
+
+          api_key=$(curl -fsS -b "$cookie_jar" -X POST http://127.0.0.1:8080/api/v2/app/rotateAPIKey \
+            | jq -r '.apiKey')
+
+          if [ -n "$api_key" ]; then
+            echo "Got API key (length=${#api_key}): ${api_key:0:8}..."
+            echo "QBIT_API_KEY=$api_key" >> "$GITHUB_ENV"
+          else
+            echo "rotateAPIKey returned empty, cannot test API key auth"
+          fi
+
+          echo "qBittorrent ready"
 
       - name: Run tests
         run: |
-          # The test harness loads credentials via `dotenv`, which requires a
-          # `.env` file to exist. Materialize it from the workflow env.
           printf '%s\n' \
             "QBIT_BASEURL=$QBIT_BASEURL" \
             "QBIT_USERNAME=$QBIT_USERNAME" \
             "QBIT_PASSWORD=$QBIT_PASSWORD" > .env
+          if [ -n "${QBIT_API_KEY:-}" ]; then
+            echo "QBIT_API_KEY=$QBIT_API_KEY" >> .env
+          fi
           cargo +nightly test

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -5,7 +5,7 @@ use std::{fmt::Debug, sync::Mutex};
 use tap::Pipe;
 use url::Url;
 
-use crate::{Client, LoginState, Qbit, ext::Cookie, model::Credential};
+use crate::{Client, LoginState, Qbit, ext::Cookie, model::{ApiKey, Credential}};
 
 pub struct QbitBuilder<C = (), R = (), E = ()> {
     credential: C,
@@ -20,6 +20,12 @@ trait IntoLoginState {
 impl IntoLoginState for Cookie {
     fn into_login_state(self) -> LoginState {
         LoginState::CookieProvided { cookie: self.0 }
+    }
+}
+
+impl IntoLoginState for ApiKey {
+    fn into_login_state(self) -> LoginState {
+        LoginState::ApiKeyProvided { api_key: format!("Bearer {}", self.0) }
     }
 }
 
@@ -70,6 +76,20 @@ impl<C, R, E> QbitBuilder<C, R, E> {
     pub fn cookie(self, cookie: impl Into<String>) -> QbitBuilder<Cookie, R, E> {
         QbitBuilder {
             credential: Cookie(cookie.into()),
+            client: self.client,
+            endpoint: self.endpoint,
+        }
+    }
+
+    /// Sets the api key for authentication.
+    ///
+    /// Note that if you have already set the credential, this method will
+    /// overwrite the credential and use the api key instead. The builder
+    /// will use the latest provided credential for authentication.
+    #[allow(private_interfaces)]
+    pub fn api_key(self, api_key: impl Into<String>) -> QbitBuilder<ApiKey, R, E> {
+        QbitBuilder {
+            credential: ApiKey(api_key.into()),
             client: self.client,
             endpoint: self.endpoint,
         }
@@ -165,6 +185,11 @@ fn test_builder() {
     QbitBuilder::new()
         .endpoint("http://localhost:8080")
         .cookie("SID=1234567890")
+        .build();
+
+    QbitBuilder::new()
+        .endpoint("http://localhost:8080")
+        .api_key("1234567890")
         .build();
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1494,13 +1494,17 @@ impl Qbit {
         for i in 0..3 {
             // If it's not the first attempt, we need to re-login
             self.login(i != 0).await?;
-
+            
+            let state = self.state();
             let mut req = self
                 .client
                 .request(method.clone(), self.url(path))
                 .check()?
-                .header(self.state().as_header_key().expect("Should always have header key if logged in"), {
-                    self.state()
+                .header({
+                    state
+                        .as_header_key()
+                        .expect("Should always have header key if logged in")}, {
+                    state
                         .as_cookie()
                         .expect("Cookie should be set after login")
                 })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1495,12 +1495,15 @@ impl Qbit {
             // If it's not the first attempt, we need to re-login
             self.login(i != 0).await?;
             
-            let state = self.state();
             let mut req = self
                 .client
                 .request(method.clone(), self.url(path))
-                .check()?
-                .header(
+                .check()?;
+
+            {
+                let state = self.state();
+
+                req = req.header(
                     state
                         .as_header_key()
                         .expect("Should always have header key if logged in"), 
@@ -1509,6 +1512,7 @@ impl Qbit {
                         .expect("Cookie should be set after login")
                 )
                 .check()?;
+            }
 
             if let Some(map) = map.as_mut() {
                 req = map(req)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@ use crate::{ext::*, model::*};
 mod builder;
 mod ext;
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 enum LoginState {
     CookieProvided {
         cookie: String,
@@ -48,7 +48,7 @@ impl LoginState {
     fn as_header_key(&self) -> Option<header::HeaderName> {
         match self {
             Self::CookieProvided { .. } => Some(header::COOKIE),
-            Self::ApiKeyProvided { .. } => Some(header::HeaderName::from_static("authentication")),
+            Self::ApiKeyProvided { .. } => Some(header::HeaderName::from_static("authorization")),
             Self::NotLoggedIn { .. } => None,
             Self::LoggedIn { .. } => Some(header::COOKIE),
         }
@@ -1500,14 +1500,14 @@ impl Qbit {
                 .client
                 .request(method.clone(), self.url(path))
                 .check()?
-                .header({
+                .header(
                     state
                         .as_header_key()
-                        .expect("Should always have header key if logged in")}, {
+                        .expect("Should always have header key if logged in"), 
                     state
                         .as_cookie()
                         .expect("Cookie should be set after login")
-                })
+                )
                 .check()?;
 
             if let Some(map) = map.as_mut() {
@@ -1647,20 +1647,25 @@ type Result<T, E = Error> = std::result::Result<T, E>;
 #[cfg(test)]
 mod test {
     use std::{
-        env,
-        ops::Deref,
-        sync::{LazyLock, OnceLock},
+        env, ops::Deref, sync::{LazyLock, Once, OnceLock},
     };
 
     use tracing::info;
 
     use super::*;
 
-    async fn prepare<'a>() -> Result<&'a Qbit> {
-        static PREPARE: LazyLock<(Credential, Url)> = LazyLock::new(|| {
+    async fn init()  {
+        static INIT: Once = Once::new();
+
+        INIT.call_once(|| {
             dotenv::dotenv().expect("Failed to load .env file");
             tracing_subscriber::fmt::init();
+        });
+    }
 
+    async fn client_with_credentials<'a>() -> Result<&'a Qbit> {
+        init().await;
+        static PREPARE: LazyLock<(Credential, Url)> = LazyLock::new(|| {
             (
                 Credential::new(
                     env::var("QBIT_USERNAME").expect("QBIT_USERNAME not set"),
@@ -1685,10 +1690,47 @@ mod test {
         }
     }
 
+    async fn client_with_api_key<'a>() -> Result<&'a Qbit> {
+        init().await;
+        static PREPARE: LazyLock<(String, Url)> = LazyLock::new(|| {
+            (
+                env::var("QBIT_API_KEY").expect("QBIT_API_KEY not set"),
+                env::var("QBIT_BASEURL")
+                    .expect("QBIT_BASEURL not set")
+                    .parse()
+                    .expect("QBIT_BASEURL is not a valid url"),
+            )
+        });
+        static API: OnceLock<Qbit> = OnceLock::new();
+
+        if let Some(api) = API.get() {
+            Ok(api)
+        } else {
+            let (api_key, url) = PREPARE.deref().clone();
+            let api = Qbit::builder()
+                .endpoint(url)
+                .api_key(api_key)
+                .build();
+            drop(API.set(api));
+            Ok(API.get().unwrap())
+        }
+    }
+
     #[cfg_attr(feature = "reqwest", tokio::test)]
     #[cfg_attr(feature = "cyper", compio::test)]
     async fn test_login() {
-        let client = prepare().await.unwrap();
+        let client = client_with_credentials().await.unwrap();
+
+        info!(
+            version = client.get_version().await.unwrap(),
+            "Login success"
+        );
+    }
+
+    #[cfg_attr(feature = "reqwest", tokio::test)]
+    #[cfg_attr(feature = "cyper", compio::test)]
+    async fn test_version_api_key() {
+        let client = client_with_api_key().await.unwrap();
 
         info!(
             version = client.get_version().await.unwrap(),
@@ -1699,7 +1741,7 @@ mod test {
     #[cfg_attr(feature = "reqwest", tokio::test)]
     #[cfg_attr(feature = "cyper", compio::test)]
     async fn test_preference() {
-        let client = prepare().await.unwrap();
+        let client = client_with_credentials().await.unwrap();
 
         client.get_preferences().await.unwrap();
     }
@@ -1707,7 +1749,7 @@ mod test {
     #[cfg_attr(feature = "reqwest", tokio::test)]
     #[cfg_attr(feature = "cyper", compio::test)]
     async fn test_add_torrent() {
-        let client = prepare().await.unwrap();
+        let client = client_with_credentials().await.unwrap();
         let arg = AddTorrentArg {
             source: TorrentSource::Urls {
                 urls: vec![
@@ -1725,7 +1767,7 @@ mod test {
     #[cfg_attr(feature = "reqwest", tokio::test)]
     #[cfg_attr(feature = "cyper", compio::test)]
     async fn test_add_torrent_file() {
-        let client = prepare().await.unwrap();
+        let client = client_with_credentials().await.unwrap();
         let arg = AddTorrentArg {
             source: TorrentSource::TorrentFiles {
                 torrents: vec![ TorrentFile {
@@ -1748,7 +1790,7 @@ mod test {
     #[cfg_attr(feature = "reqwest", tokio::test)]
     #[cfg_attr(feature = "cyper", compio::test)]
     async fn test_get_torrent_list() {
-        let client = prepare().await.unwrap();
+        let client = client_with_credentials().await.unwrap();
         let list = client
             .get_torrent_list(GetTorrentListArg::default())
             .await

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,9 @@ enum LoginState {
     CookieProvided {
         cookie: String,
     },
+    ApiKeyProvided {
+        api_key: String,
+    },
     NotLoggedIn {
         credential: Credential,
     },
@@ -42,9 +45,19 @@ enum LoginState {
 }
 
 impl LoginState {
+    fn as_header_key(&self) -> Option<header::HeaderName> {
+        match self {
+            Self::CookieProvided { .. } => Some(header::COOKIE),
+            Self::ApiKeyProvided { .. } => Some(header::HeaderName::from_static("authentication")),
+            Self::NotLoggedIn { .. } => None,
+            Self::LoggedIn { .. } => Some(header::COOKIE),
+        }
+    }
+
     fn as_cookie(&self) -> Option<&str> {
         match self {
             Self::CookieProvided { cookie } => Some(cookie),
+            Self::ApiKeyProvided { api_key } => Some(api_key),
             Self::NotLoggedIn { .. } => None,
             Self::LoggedIn { cookie, .. } => Some(cookie),
         }
@@ -53,6 +66,7 @@ impl LoginState {
     fn as_credential(&self) -> Option<&Credential> {
         match self {
             Self::CookieProvided { .. } => None,
+            Self::ApiKeyProvided { .. } => None,
             Self::NotLoggedIn { credential } => Some(credential),
             Self::LoggedIn { credential, .. } => Some(credential),
         }
@@ -61,6 +75,7 @@ impl LoginState {
     fn add_cookie(&mut self, cookie: String) {
         match self {
             Self::CookieProvided { .. } => {}
+            Self::ApiKeyProvided { .. } => {} // TODO: Is this right? Might need to add api_key to LoggedIn state.
             Self::LoggedIn { credential, .. } | Self::NotLoggedIn { credential } => {
                 *self = Self::LoggedIn {
                     cookie,
@@ -1484,7 +1499,7 @@ impl Qbit {
                 .client
                 .request(method.clone(), self.url(path))
                 .check()?
-                .header(header::COOKIE, {
+                .header(self.state().as_header_key().expect("Should always have header key if logged in"), {
                     self.state()
                         .as_cookie()
                         .expect("Cookie should be set after login")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,7 @@ impl LoginState {
     fn as_header_key(&self) -> Option<header::HeaderName> {
         match self {
             Self::CookieProvided { .. } => Some(header::COOKIE),
-            Self::ApiKeyProvided { .. } => Some(header::HeaderName::from_static("authorization")),
+            Self::ApiKeyProvided { .. } => Some(header::AUTHORIZATION),
             Self::NotLoggedIn { .. } => None,
             Self::LoggedIn { .. } => Some(header::COOKIE),
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,7 +75,7 @@ impl LoginState {
     fn add_cookie(&mut self, cookie: String) {
         match self {
             Self::CookieProvided { .. } => {}
-            Self::ApiKeyProvided { .. } => {} // TODO: Is this right? Might need to add api_key to LoggedIn state.
+            Self::ApiKeyProvided { .. } => {}
             Self::LoggedIn { credential, .. } | Self::NotLoggedIn { credential } => {
                 *self = Self::LoggedIn {
                     cookie,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -564,6 +564,10 @@ impl Qbit {
                     StatusCode::UNSUPPORTED_MEDIA_TYPE => {
                         Some(Error::ApiError(ApiError::TorrentFileInvalid))
                     }
+                    // qBittorrent 5.2.0+: 409 = all torrents failed (e.g. duplicate)
+                    StatusCode::CONFLICT => {
+                        Some(Error::ApiError(ApiError::TorrentAddFailed))
+                    }
                     _ => None,
                 })?
                 .end(),
@@ -1413,17 +1417,18 @@ impl Qbit {
     pub async fn login(&self, force: bool) -> Result<()> {
         let re_login = force || { self.state().as_header().1.is_none() };
         if re_login {
+            let credential = match self.state().as_credential() {
+                Some(credential) => credential.clone(),
+                None => {
+                    trace!("API key or cookie auth in use, skipping login");
+                    return Ok(());
+                }
+            };
             debug!("Cookie not found, logging in");
             self.client
                 .request(Method::POST, self.url("auth/login"))
                 .check()?
-                .pipe(|req| {
-                    req.form(
-                        self.state()
-                            .as_credential()
-                            .expect("Credential should be set if cookie is not set"),
-                    )
-                })
+                .pipe(|req| req.form(&credential))
                 .check()?
                 .send()
                 .await?
@@ -1587,6 +1592,10 @@ pub enum ApiError {
     #[error("Torrent file is not valid")]
     TorrentFileInvalid,
 
+    /// Torrent could not be added (e.g. duplicate)
+    #[error("Torrent could not be added")]
+    TorrentAddFailed,
+
     /// `newUrl` is not a valid URL
     #[error("`newUrl` is not a valid URL")]
     InvalidTrackerUrl,
@@ -1683,27 +1692,30 @@ mod test {
 
     async fn client_with_api_key<'a>() -> Result<&'a Qbit> {
         init().await;
-        static PREPARE: LazyLock<(String, Url)> = LazyLock::new(|| {
-            (
-                env::var("QBIT_API_KEY").expect("QBIT_API_KEY not set"),
-                env::var("QBIT_BASEURL")
-                    .expect("QBIT_BASEURL not set")
-                    .parse()
-                    .expect("QBIT_BASEURL is not a valid url"),
-            )
+        static PREPARE: LazyLock<Option<(String, Url)>> = LazyLock::new(|| {
+            let api_key = env::var("QBIT_API_KEY").ok()?;
+            let url = env::var("QBIT_BASEURL")
+                .expect("QBIT_BASEURL not set")
+                .parse()
+                .expect("QBIT_BASEURL is not a valid url");
+            Some((api_key, url))
         });
-        static API: OnceLock<Qbit> = OnceLock::new();
+        static API: OnceLock<Option<Qbit>> = OnceLock::new();
 
-        if let Some(api) = API.get() {
+        let prepared = PREPARE.deref();
+        let Some((api_key, url)) = prepared.clone() else {
+            return Err(Error::ApiError(ApiError::NotLoggedIn));
+        };
+
+        if let Some(Some(api)) = API.get() {
             Ok(api)
         } else {
-            let (api_key, url) = PREPARE.deref().clone();
             let api = Qbit::builder()
                 .endpoint(url)
                 .api_key(api_key)
                 .build();
-            drop(API.set(api));
-            Ok(API.get().unwrap())
+            drop(API.set(Some(api)));
+            Ok(API.get().unwrap().as_ref().unwrap())
         }
     }
 
@@ -1721,7 +1733,13 @@ mod test {
     #[cfg_attr(feature = "reqwest", tokio::test)]
     #[cfg_attr(feature = "cyper", compio::test)]
     async fn test_version_api_key() {
-        let client = client_with_api_key().await.unwrap();
+        let client = match client_with_api_key().await {
+            Ok(c) => c,
+            Err(_) => {
+                eprintln!("QBIT_API_KEY not set, skipping API key test");
+                return;
+            }
+        };
 
         info!(
             version = client.get_version().await.unwrap(),
@@ -1762,8 +1780,8 @@ mod test {
         let arg = AddTorrentArg {
             source: TorrentSource::TorrentFiles {
                 torrents: vec![ TorrentFile {
-                    filename: "alice.torrent".into(),
-                    data: client::get("https://github.com/webtorrent/webtorrent-fixtures/raw/d20eec0ae19a18b088cf7b221ff70bb9f840c226/fixtures/alice.torrent")
+                    filename: "leaves.torrent".into(),
+                    data: client::get("https://github.com/webtorrent/webtorrent-fixtures/raw/d20eec0ae19a18b088cf7b221ff70bb9f840c226/fixtures/leaves.torrent")
                         .await
                         .unwrap()
                         .bytes()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,21 +45,12 @@ enum LoginState {
 }
 
 impl LoginState {
-    fn as_header_key(&self) -> Option<header::HeaderName> {
+    fn as_header(&self) -> (Option<header::HeaderName>, Option<&str>) {
         match self {
-            Self::CookieProvided { .. } => Some(header::COOKIE),
-            Self::ApiKeyProvided { .. } => Some(header::AUTHORIZATION),
-            Self::NotLoggedIn { .. } => None,
-            Self::LoggedIn { .. } => Some(header::COOKIE),
-        }
-    }
-
-    fn as_cookie(&self) -> Option<&str> {
-        match self {
-            Self::CookieProvided { cookie } => Some(cookie),
-            Self::ApiKeyProvided { api_key } => Some(api_key),
-            Self::NotLoggedIn { .. } => None,
-            Self::LoggedIn { cookie, .. } => Some(cookie),
+            Self::CookieProvided { cookie } => (Some(header::COOKIE), Some(cookie)),
+            Self::ApiKeyProvided { api_key } => (Some(header::AUTHORIZATION), Some(api_key)),
+            Self::NotLoggedIn { .. } => (None, None),
+            Self::LoggedIn { cookie, .. } => (Some(header::COOKIE), Some(cookie)),
         }
     }
 
@@ -124,7 +115,7 @@ impl Qbit {
         self.state
             .lock()
             .unwrap()
-            .as_cookie()
+            .as_header().1
             .map(ToOwned::to_owned)
     }
 
@@ -1420,7 +1411,7 @@ impl Qbit {
     /// Set force to `true` to force re-login regardless if cookie is already
     /// set.
     pub async fn login(&self, force: bool) -> Result<()> {
-        let re_login = force || { self.state().as_cookie().is_none() };
+        let re_login = force || { self.state().as_header().0.is_none() };
         if re_login {
             debug!("Cookie not found, logging in");
             self.client
@@ -1494,25 +1485,21 @@ impl Qbit {
         for i in 0..3 {
             // If it's not the first attempt, we need to re-login
             self.login(i != 0).await?;
+
+            let (header_key, header_value) = {
+                let state = self.state();
+                let (header_key, header_value) = state.as_header();
+                let header_key = header_key.expect("Should always have header key if logged in");
+                let header_value = header_value.expect("Should always have header value if logged in");
+                (header_key.to_owned(), header_value.to_owned())
+            };
             
             let mut req = self
                 .client
                 .request(method.clone(), self.url(path))
+                .check()?
+                .header(header_key, header_value)
                 .check()?;
-
-            {
-                let state = self.state();
-
-                req = req.header(
-                    state
-                        .as_header_key()
-                        .expect("Should always have header key if logged in"), 
-                    state
-                        .as_cookie()
-                        .expect("Cookie should be set after login")
-                )
-                .check()?;
-            }
 
             if let Some(map) = map.as_mut() {
                 req = map(req)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1411,7 +1411,7 @@ impl Qbit {
     /// Set force to `true` to force re-login regardless if cookie is already
     /// set.
     pub async fn login(&self, force: bool) -> Result<()> {
-        let re_login = force || { self.state().as_header().0.is_none() };
+        let re_login = force || { self.state().as_header().1.is_none() };
         if re_login {
             debug!("Cookie not found, logging in");
             self.client

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -12,6 +12,9 @@ use tap::Pipe;
 
 mod_use::mod_use![app, log, sync, torrent, transfer, search];
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ApiKey(pub String);
+
 /// Username and password used to authenticate with qBittorrent.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Credential {


### PR DESCRIPTION
As of qbittorrent 5.2.0 api key support was added (see [here](https://github.com/qbittorrent/qBittorrent/wiki/API-Key-Authentication-(%E2%89%A5v5.2.0)) ).

This Pr add support for api key auth as an alternative to the username/password and cookie auth already provided.

~~There is one section I think is not right, see inline comment around 1493 of lib.rs~~
I think I have this correct now.