### PR TITLE
fix!: remove deprecated cookie field from AddTorrentArg

### DIFF
--- a/src/model/torrent.rs
+++ b/src/model/torrent.rs
@@ -447,9 +447,6 @@ pub struct AddTorrentArg {
     #[serde(skip_serializing_if = "Option::is_none")]
     /// Download folder
     pub savepath: Option<String>,
-    /// Cookie sent to download the .torrent file
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub cookie: Option<String>,
     /// Category for the torrent
     #[serde(skip_serializing_if = "Option::is_none")]
     pub category: Option<String>,


### PR DESCRIPTION
BREAKING CHANGE: The `cookie` parameter was removed from the `torrents/add` endpoint in qBittorrent Web API v2.11.3.