### PR TITLE
feat: add get_process_info endpoint

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,6 +147,17 @@ impl Qbit {
             .map_err(Into::into)
     }
 
+    /// Get process info, including launch time.
+    ///
+    /// Added in qBittorrent 5.2.0 (Web API v2.15.1).
+    pub async fn get_process_info(&self) -> Result<ProcessInfo> {
+        self.get("app/processInfo")
+            .await?
+            .json()
+            .await
+            .map_err(Into::into)
+    }
+
     pub async fn shutdown(&self) -> Result<()> {
         self.post("app/shutdown").await?.end()
     }

--- a/src/model/app.rs
+++ b/src/model/app.rs
@@ -19,6 +19,14 @@ pub struct BuildInfo {
     bitness: i8,
 }
 
+/// Process info returned by `app/processInfo`.
+/// Added in qBittorrent 5.2.0 (Web API v2.15.1).
+#[derive(Debug, Clone, serde::Deserialize, PartialEq, Eq)]
+pub struct ProcessInfo {
+    /// Process launch time as UTC epoch seconds.
+    pub launch_time: i64,
+}
+
 #[cfg_attr(feature = "builder", derive(typed_builder::TypedBuilder))]
 #[cfg_attr(
     feature = "builder",


### PR DESCRIPTION
Adds `get_process_info()` for the `app/processInfo` endpoint, returning `ProcessInfo { launch_time }` as UTC epoch seconds. Added in qBittorrent 5.2.0 (Web API v2.15.1).