### PR TITLE
feat: add get_cookies and set_cookies endpoints

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,6 +147,31 @@ impl Qbit {
             .map_err(Into::into)
     }
 
+    /// Get cookies stored in the qBittorrent WebUI.
+    ///
+    /// Added in qBittorrent 5.2.0 (Web API v2.11.3).
+    pub async fn get_cookies(&self) -> Result<Vec<CookieEntry>> {
+        self.get("app/cookies")
+            .await?
+            .json()
+            .await
+            .map_err(Into::into)
+    }
+
+    /// Set cookies for the qBittorrent WebUI.
+    ///
+    /// Added in qBittorrent 5.2.0 (Web API v2.11.3).
+    pub async fn set_cookies(&self, cookies: &[SetCookieArg]) -> Result<()> {
+        #[derive(Serialize)]
+        struct Arg<'a> {
+            cookies: &'a str,
+        }
+        let json = serde_json::to_string(cookies)?;
+        self.post_with("app/setCookies", &Arg { cookies: &json })
+            .await?
+            .end()
+    }
+
     pub async fn shutdown(&self) -> Result<()> {
         self.post("app/shutdown").await?.end()
     }

--- a/src/model/app.rs
+++ b/src/model/app.rs
@@ -415,3 +415,37 @@ impl Visitor<'_> for ScanDirsVisitor {
         Ok(ScanDirValue::Path(PathBuf::from(v)))
     }
 }
+
+/// A single cookie entry returned by `app/cookies` (GET).
+/// All fields are guaranteed to be present in the response.
+/// Added in qBittorrent 5.2.0 (Web API v2.11.3).
+#[derive(Debug, Clone, serde::Deserialize, PartialEq, Eq)]
+pub struct CookieEntry {
+    /// Cookie name
+    pub name: String,
+    /// Cookie domain
+    pub domain: String,
+    /// Cookie path
+    pub path: String,
+    /// Cookie value
+    pub value: String,
+    /// Cookie expiration date (seconds since epoch)
+    pub expiration_date: i64,
+}
+
+/// Arguments for setting cookies via `app/setCookies` (POST).
+/// All fields are optional.
+/// Added in qBittorrent 5.2.0 (Web API v2.11.3).
+#[derive(Debug, Clone, serde::Serialize, PartialEq, Eq)]
+pub struct SetCookieArg {
+    /// Cookie name
+    pub name: Option<String>,
+    /// Cookie domain
+    pub domain: Option<String>,
+    /// Cookie path
+    pub path: Option<String>,
+    /// Cookie value
+    pub value: Option<String>,
+    /// Cookie expiration date (seconds since epoch)
+    pub expiration_date: Option<i64>,
+}


### PR DESCRIPTION
Adds `get_cookies()` and `set_cookies()` for managing WebUI cookies. Added in qBittorrent 5.2.0 (Web API v2.11.3).