### PR TITLE
feat: add get_speed_limits and set_speed_limits endpoints

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -283,6 +283,26 @@ impl Qbit {
         self.post("transfer/toggleSpeedLimitsMode").await?.end()
     }
 
+    /// Get global and alternative speed limits (KiB/s, -1 = unlimited).
+    ///
+    /// Added in qBittorrent 5.2.0 (Web API v2.16.0).
+    pub async fn get_speed_limits(&self) -> Result<SpeedLimits> {
+        self.get("transfer/getSpeedLimits")
+            .await?
+            .json()
+            .await
+            .map_err(Into::into)
+    }
+
+    /// Set global and alternative speed limits (KiB/s, -1 = unlimited).
+    ///
+    /// Added in qBittorrent 5.2.0 (Web API v2.16.0).
+    pub async fn set_speed_limits(&self, limits: &SpeedLimits) -> Result<()> {
+        self.post_with("transfer/setSpeedLimits", limits)
+            .await?
+            .end()
+    }
+
     pub async fn get_download_limit(&self) -> Result<u64> {
         self.get("transfer/downloadLimit")
             .await?

--- a/src/model/transfer.rs
+++ b/src/model/transfer.rs
@@ -27,3 +27,23 @@ pub enum ConnectionStatus {
     #[serde(other)]
     Unknown,
 }
+
+/// Global and alternative speed limits returned by `transfer/getSpeedLimits`.
+/// All values are in KiB/s, `-1` means unlimited.
+/// Added in qBittorrent 5.2.0 (Web API v2.16.0).
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct SpeedLimits {
+    /// Global upload limit (KiB/s, -1 = unlimited)
+    #[serde(rename = "up_limit")]
+    pub upload_limit: i64,
+    /// Global download limit (KiB/s, -1 = unlimited)
+    #[serde(rename = "dl_limit")]
+    pub download_limit: i64,
+    /// Alternative upload limit (KiB/s, -1 = unlimited)
+    #[serde(rename = "alt_up_limit")]
+    pub alternative_upload_limit: i64,
+    /// Alternative download limit (KiB/s, -1 = unlimited)
+    #[serde(rename = "alt_dl_limit")]
+    pub alternative_download_limit: i64,
+}


### PR DESCRIPTION
Adds `get_speed_limits()` and `set_speed_limits()` for managing global and alternative speed limits. Added in qBittorrent 5.2.0 (Web API v2.16.0).