### PR TITLE
feat: add piece availability endpoint

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -375,6 +375,23 @@ impl Qbit {
             .map_err(Into::into)
     }
 
+    /// Get the availability (number of distributed copies) of each piece
+    /// of a torrent. Returns a vector where each element is the availability
+    /// count for the corresponding piece index.
+    ///
+    /// Added in qBittorrent 5.2.0 (Web API v2.15.1).
+    pub async fn get_torrent_piece_availability(
+        &self,
+        hash: impl AsRef<str> + Send + Sync,
+    ) -> Result<Vec<i64>> {
+        self.get_with("torrents/pieceAvailability", &HashArg::new(hash.as_ref()))
+            .await
+            .and_then(|r| r.map_status(TORRENT_NOT_FOUND))?
+            .json()
+            .await
+            .map_err(Into::into)
+    }
+
     pub async fn get_torrent_trackers(
         &self,
         hash: impl AsRef<str> + Send + Sync,

--- a/src/model/torrent.rs
+++ b/src/model/torrent.rs
@@ -245,6 +245,9 @@ pub struct TorrentProperty {
     pub addition_date: Option<i64>,
     /// Torrent completion date (unix timestamp)
     pub completion_date: Option<i64>,
+    /// Number of distributed copies of the torrent's selected files.
+    /// Added in qBittorrent 5.2.0 (Web API v2.15.1).
+    pub availability: Option<f64>,
     /// Torrent creator
     pub created_by: Option<String>,
     /// Torrent average download speed (bytes/second)


### PR DESCRIPTION
Adds `get_torrent_piece_availability()` for per-piece availability via `GET torrents/pieceAvailability`. Also adds `availability` field to `TorrentProperty`. Added in qBittorrent 5.2.0 (Web API v2.15.1).