### PR TITLE
fix: apply skip_serializing_none before Serialize derive on various structs

### DIFF
--- a/src/endpoint/log.rs
+++ b/src/endpoint/log.rs
@@ -20,8 +20,8 @@ impl Qbit {
         &self,
         last_known_id: impl Into<Option<i64>> + Send + Sync,
     ) -> Result<Vec<PeerLog>> {
-        #[derive(Serialize)]
         #[skip_serializing_none]
+        #[derive(Serialize)]
         struct Arg {
             last_known_id: Option<i64>,
         }

--- a/src/endpoint/search.rs
+++ b/src/endpoint/search.rs
@@ -91,8 +91,8 @@ impl Qbit {
         &self,
         id: impl Into<Option<i64>> + Send + Sync,
     ) -> Result<Vec<SearchJobStatus>> {
-        #[derive(Serialize)]
         #[skip_serializing_none]
+        #[derive(Serialize)]
         struct Arg {
             id: Option<i64>,
         }
@@ -129,8 +129,8 @@ impl Qbit {
         limit: impl Into<Option<i64>> + Send + Sync,
         offset: impl Into<Option<i64>> + Send + Sync,
     ) -> Result<SearchResults> {
-        #[derive(Serialize)]
         #[skip_serializing_none]
+        #[derive(Serialize)]
         struct Arg {
             id: i64,
             limit: Option<i64>,

--- a/src/endpoint/sync.rs
+++ b/src/endpoint/sync.rs
@@ -6,8 +6,8 @@ use crate::{Qbit, Result, ext::*, model::*};
 impl Qbit {
     /// Return main-data changes since the supplied response ID.
     pub async fn sync(&self, rid: impl Into<Option<i64>> + Send + Sync) -> Result<SyncData> {
-        #[derive(Serialize)]
         #[skip_serializing_none]
+        #[derive(Serialize)]
         struct Arg {
             rid: Option<i64>,
         }

--- a/src/endpoint/torrent.rs
+++ b/src/endpoint/torrent.rs
@@ -197,8 +197,8 @@ impl Qbit {
         hashes: impl Into<Hashes> + Send + Sync,
         delete_files: impl Into<Option<bool>> + Send + Sync,
     ) -> Result<()> {
-        #[derive(Serialize)]
         #[skip_serializing_none]
+        #[derive(Serialize)]
         #[serde(rename_all = "camelCase")]
         struct Arg {
             hashes: Hashes,
@@ -840,8 +840,8 @@ impl Qbit {
         hashes: impl Into<Hashes> + Send + Sync,
         tags: Option<impl Into<Sep<String, ','>> + Send>,
     ) -> Result<()> {
-        #[derive(Serialize)]
         #[skip_serializing_none]
+        #[derive(Serialize)]
         struct Arg {
             hashes: String,
             tags: Option<String>,

--- a/src/model/app.rs
+++ b/src/model/app.rs
@@ -28,6 +28,7 @@ pub struct ProcessInfo {
     pub launch_time: i64,
 }
 
+#[skip_serializing_none]
 #[cfg_attr(feature = "builder", derive(typed_builder::TypedBuilder))]
 #[cfg_attr(
     feature = "builder",
@@ -37,7 +38,6 @@ pub struct ProcessInfo {
 ///
 /// Optional fields allow callers to update only selected settings.
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize, PartialEq)]
-#[skip_serializing_none]
 pub struct Preferences {
     /// Currently selected language (e.g. en_GB for English)
     pub locale: Option<String>,
@@ -464,4 +464,22 @@ pub struct SetCookieArg {
     pub value: Option<String>,
     /// Cookie expiration date (seconds since epoch)
     pub expiration_date: Option<i64>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn preferences_skips_none_fields() {
+        let prefs = Preferences {
+            save_path: Some("/data/torrents".to_string()),
+            auto_tmm_enabled: Some(true),
+            ..Default::default()
+        };
+        let json = serde_json::to_string(&prefs).unwrap();
+        assert!(json.contains("save_path"));
+        assert!(json.contains("auto_tmm_enabled"));
+        assert!(!json.contains("null"), "None fields should be skipped, got: {json}");
+    }
 }

--- a/src/model/log.rs
+++ b/src/model/log.rs
@@ -62,8 +62,8 @@ pub enum LogLevel {
     feature = "builder",
     builder(field_defaults(default, setter(strip_option)))
 )]
-#[derive(Debug, Clone, serde::Serialize, PartialEq, Eq)]
 #[skip_serializing_none]
+#[derive(Debug, Clone, serde::Serialize, PartialEq, Eq)]
 pub struct GetLogsArg {
     /// Include normal messages (default: `true`)
     pub normal: Option<bool>,
@@ -75,4 +75,25 @@ pub struct GetLogsArg {
     pub critical: Option<bool>,
     /// Exclude messages with "message id" <= `last_known_id` (default: `-1`)
     pub last_known_id: Option<i64>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::GetLogsArg;
+
+    #[test]
+    fn get_logs_arg_skips_none_fields() {
+        let arg = GetLogsArg {
+            normal: None,
+            info: None,
+            warning: None,
+            critical: None,
+            last_known_id: None,
+        };
+        let json = serde_json::to_string(&arg).unwrap();
+        assert!(
+            !json.contains("null"),
+            "None fields should be skipped, got: {json}"
+        );
+    }
 }

--- a/src/model/torrent.rs
+++ b/src/model/torrent.rs
@@ -405,8 +405,8 @@ impl Display for Hashes {
     feature = "builder",
     builder(field_defaults(default, setter(strip_option)))
 )]
-#[derive(Debug, Clone, PartialEq, Default, serde::Serialize)]
 #[skip_serializing_none]
+#[derive(Debug, Clone, PartialEq, Default, serde::Serialize)]
 pub struct GetTorrentListArg {
     /// Filter torrent list by state. Allowed state filters: `all`,
     /// `downloading`, `seeding`, `completed`, `paused`, `active`, `inactive`,
@@ -471,8 +471,8 @@ fn is_torrent_files(source: &TorrentSource) -> bool {
     feature = "builder",
     builder(field_defaults(default, setter(strip_option)))
 )]
-#[derive(Debug, Clone, PartialEq, serde::Serialize, Default)]
 #[skip_serializing_none]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, Default)]
 pub struct AddTorrentArg {
     /// URLs or torrent files to add.
     #[serde(flatten)]
@@ -635,6 +635,36 @@ mod torrent_source_tests {
 
         // The trimmed-down arg is now safe to urlencode.
         serde_urlencoded::to_string(&arg).expect("arg without binary source must urlencode");
+    }
+}
+
+#[cfg(test)]
+mod skip_serializing_none_tests {
+    use super::{AddTorrentArg, GetTorrentListArg, TorrentSource};
+
+    #[test]
+    fn get_torrent_list_arg_skips_none_fields() {
+        let arg = GetTorrentListArg::default();
+        let json = serde_json::to_string(&arg).unwrap();
+        assert!(
+            !json.contains("null"),
+            "None fields should be skipped, got: {json}"
+        );
+    }
+
+    #[test]
+    fn add_torrent_arg_skips_none_fields() {
+        let arg = AddTorrentArg {
+            source: TorrentSource::Urls {
+                urls: super::Sep::from(vec![]),
+            },
+            ..Default::default()
+        };
+        let json = serde_json::to_string(&arg).unwrap();
+        assert!(
+            !json.contains("null"),
+            "None fields should be skipped, got: {json}"
+        );
     }
 }
 


### PR DESCRIPTION
Fixes #60

According to [the docs](https://docs.rs/serde_with/latest/serde_with/attr.skip_serializing_none.html), `skip_serializing_none` must be applied before the `Serialize` attribute to take effect. When it is placed after, `None` fields are serialized as `null` instead of being omitted.

Encountered this issue for `Preferences` (`400 Bad Request`) but there are multiple affected structs.